### PR TITLE
Feat: Add detailed logging to DeepResearchCoordinator for Step 1 proc…

### DIFF
--- a/agents/deepresearch/coordinator/agent.py
+++ b/agents/deepresearch/coordinator/agent.py
@@ -188,35 +188,44 @@ def after_coord_model(
                 if current_step_being_processed == 1: # Planner response
                     state[RESEARCH_PLAN_KEY] = response_content
                     logger.info("Coordinator state (Step 1 - Planner Response): Stored research plan.")
+                    logger.info(f"Coordinator state (Step 1 - Planner Response): Raw plan content (first 500 chars): {str(response_content)[:500]}")
                     try:
                         tasks = []
                         current_task_lines = []
-                        lines = response_content.strip().splitlines()
-                        plan_title = lines[0] if lines and lines[0].startswith("#") else "Research Plan"
-                        start_index = 1 if lines and lines[0].startswith("#") else 0
-                        for line in lines[start_index:]:
-                            stripped_line = line.strip()
-                            is_separator = stripped_line == '---'
-                            is_new_task = stripped_line.startswith("**Task_ID:**")
-                            if (is_separator or is_new_task) and current_task_lines:
-                                task_text = "\n".join(current_task_lines).strip()
-                                if "**Task_ID:**" in task_text: tasks.append(task_text)
-                                current_task_lines = []
-                            if not is_separator: current_task_lines.append(line)
-                        if current_task_lines:
-                             task_text = "\n".join(current_task_lines).strip()
-                             if "**Task_ID:**" in task_text: tasks.append(task_text)
-                        
+                        # Ensure response_content is not None and is a string before splitting
+                        if response_content and isinstance(response_content, str):
+                            lines = response_content.strip().splitlines()
+                            plan_title = lines[0] if lines and lines[0].startswith("#") else "Research Plan"
+                            start_index = 1 if lines and lines[0].startswith("#") else 0
+                            for line in lines[start_index:]:
+                                stripped_line = line.strip()
+                                is_separator = stripped_line == '---'
+                                is_new_task = stripped_line.startswith("**Task_ID:**")
+                                if (is_separator or is_new_task) and current_task_lines:
+                                    task_text = "\n".join(current_task_lines).strip()
+                                    if "**Task_ID:**" in task_text: tasks.append(task_text)
+                                    current_task_lines = []
+                                if not is_separator: current_task_lines.append(line)
+                            if current_task_lines:
+                                 task_text = "\n".join(current_task_lines).strip()
+                                 if "**Task_ID:**" in task_text: tasks.append(task_text)
+                        else:
+                            logger.error(f"Coordinator state (Step 1 - Planner Response): Planner response_content is None or not a string. Content: {response_content}")
+                            # tasks will remain empty
+
                         if not tasks:
                              logger.error("Coordinator state (Step 1 - Planner Response): Failed to parse any valid tasks from the plan. Plan content was: " + str(response_content)[:300])
+                             logger.info(f"Coordinator state (Step 1 - Planner Response): Task parsing resulted in {len(tasks)} tasks. step_completed_in_callback is being set to False.")
                              step_completed_in_callback = False
                         else:
                              state[PARSED_RESEARCH_TASKS_KEY] = tasks
                              state[CURRENT_RESEARCH_TASK_INDEX_KEY] = 0
                              logger.info(f"Coordinator state (Step 1 - Planner Response): Parsed {len(tasks)} tasks. Setting step_completed_in_callback = True.")
+                             logger.info(f"Coordinator state (Step 1 - Planner Response): Successfully parsed {len(tasks)} tasks. step_completed_in_callback is being set to True.")
                              step_completed_in_callback = True
                     except Exception as e:
                          logger.error(f"Coordinator state (Step 1 - Planner Response): Error parsing research plan: {e}. Plan: {str(response_content)[:300]}", exc_info=True)
+                         logger.info(f"Coordinator state (Step 1 - Planner Response): Exception during task parsing. step_completed_in_callback is being set to False.")
                          step_completed_in_callback = False
                 elif current_step_being_processed == 2: # Researcher response
                     task_index = state.get(CURRENT_RESEARCH_TASK_INDEX_KEY, 0)
@@ -260,6 +269,12 @@ def after_coord_model(
                     elif current_step_being_processed != 2: # For other steps, if completed, advance
                         next_step = current_step_being_processed + 1
                     # If step 2 completed a task but not all tasks, next_step remains current_step_being_processed
+            else: # if step_completed_in_callback is False
+                next_step = current_step_being_processed
+
+            # NEW LOGGING FOR STEP 1 CONCLUSION - Placed after next_step is determined
+            if current_step_being_processed == 1:
+                logger.info(f"Coordinator state (Step 1 Conclusion): current_step_being_processed={current_step_being_processed}, step_completed_in_callback={step_completed_in_callback}, determined next_step value={next_step}")
         else:
              logger.warning(f"Coordinator state: Received function response from unexpected sub-agent '{func_response_name}'. Expected '{expected_agent_name}'.")
 
@@ -324,12 +339,16 @@ def after_coord_model(
     if next_step != current_step_being_processed:
         state[COORD_STEP_KEY] = next_step
         logger.info(f"Coordinator state: Advanced COORD_STEP_KEY in state to {next_step}.")
+        if current_step_being_processed == 1 and next_step != current_step_being_processed : # Log if Step 1 successfully advanced
+            logger.info(f"Coordinator state (Step 1 Conclusion): Successfully advanced COORD_STEP_KEY from 1 to {next_step}.")
     elif step_completed_in_callback and current_step_being_processed == 2 and (next_task_index < len(parsed_tasks)): # Special case for step 2 looping over tasks
         logger.info(f"Coordinator state: Step 2 task completed, but more tasks remain. Staying on COORD_STEP_KEY {current_step_being_processed} to process next task.")
     elif step_completed_in_callback:
          logger.info(f"Coordinator state: Step {current_step_being_processed} action processing completed according to callback logic, but next_step is still {next_step}. Waiting for next agent turn if applicable.")
     else:
          logger.info(f"Coordinator state: Staying on step {current_step_being_processed} for further processing or sub-agent response (step_completed_in_callback is False).")
+    if current_step_being_processed == 1 and next_step == current_step_being_processed:
+        logger.warning(f"Coordinator state (Step 1 Conclusion): COORD_STEP_KEY remains at {current_step_being_processed}. Agent will likely re-run Step 1 or stall. This usually indicates a problem in Step 1 processing if it was expected to advance.")
 
 
 deep_research_coordinator = LlmAgent(


### PR DESCRIPTION
…essing

This commit introduces enhanced diagnostic logging in the `after_coord_model` method of the `DeepResearchCoordinatorAgent`, specifically for when `current_step_being_processed == 1` (after the ResearchPlanner agent has run).

The new logging will help trace:
- The raw output from the planner.
- The success or failure of parsing tasks from the planner's output.
- The value of `step_completed_in_callback` after task parsing.
- The calculated `next_step` for the coordinator.
- Whether the `COORD_STEP_KEY` is successfully advanced from 1 to 2, or if it remains at 1.

These logs are intended to help diagnose why I might be halting after the planning phase instead of proceeding to execute research tasks.